### PR TITLE
swift 5 support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "krzyzanowskim/CryptoSwift"
-github "ashleymills/Reachability.swift"
+github "krzyzanowskim/CryptoSwift" == 0.15.0
+github "ashleymills/Reachability.swift" "v4.3.0"
 github "icanzilb/TaskQueue"
-github "daltoniam/Starscream"
+github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ashleymills/Reachability.swift" "v4.1.0"
-github "daltoniam/Starscream" "3.0.5"
+github "ashleymills/Reachability.swift" "v4.3.0"
+github "daltoniam/Starscream" "3.0.6"
 github "icanzilb/TaskQueue" "1.1.1"
-github "krzyzanowskim/CryptoSwift" "0.9.0"
+github "krzyzanowskim/CryptoSwift" "0.15.0"


### PR DESCRIPTION
### Description of the pull request

...Update Pusher Web Socket dependencies

#### Why is the change necessary?

... This change is necessary in order to compile project for Swift 5
